### PR TITLE
Passing null to parent construct...

### DIFF
--- a/src/Embed/Maps.php
+++ b/src/Embed/Maps.php
@@ -40,7 +40,7 @@ class Maps extends Embed
 	 */
 	public function __construct(Registry $options = null, Uri $uri = null, Http $http = null)
 	{
-		parent::__construct($options = null, $uri = null);
+		parent::__construct($options, $uri);
 		$this->http = $http ? $http : new Http($this->options);
 	}
 


### PR DESCRIPTION
Cannot pass the URI instance because it sets it to `null`.
