### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/Tests/JGoogleDataPicasaPhotoTest.php
+++ b/Tests/JGoogleDataPicasaPhotoTest.php
@@ -99,14 +99,14 @@ class JGoogleDataPicasaPhotoTest extends GoogleTestCase
 	}
 
 	/**
-	 * Tests the getURL method
+	 * Tests the getUrl method
 	 *
 	 * @group	JGoogle
 	 * @return void
 	 */
-	public function testGetURL()
+	public function testGetUrl()
 	{
-		$url = $this->object->getURL();
+		$url = $this->object->getUrl();
 		$this->assertEquals($url, 'https://lh3.googleusercontent.com/-VQfLCrQyGuw/UAYBmwBJZ3I/AAAAAAAAF-k/8y_1iBPJcdQ/Photo2.jpg');
 	}
 

--- a/Tests/JGoogleEmbedMapsTest.php
+++ b/Tests/JGoogleEmbedMapsTest.php
@@ -80,30 +80,30 @@ class JGoogleEmbedMapsTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the getMapID method
+	 * Tests the getMapId method
 	 *
 	 * @group	JGoogle
 	 * @return void
 	 */
-	public function testGetMapID()
+	public function testGetMapId()
 	{
-		$id = $this->object->getMapID();
+		$id = $this->object->getMapId();
 		$this->assertEquals($id, 'map_canvas');
 
 		$this->object->setOption('mapid', 'canvas');
-		$id = $this->object->getMapID();
+		$id = $this->object->getMapId();
 		$this->assertEquals($id, 'canvas');
 	}
 
 	/**
-	 * Tests the setMapID method
+	 * Tests the setMapId method
 	 *
 	 * @group	JGoogle
 	 * @return void
 	 */
-	public function testSetMapID()
+	public function testSetMapId()
 	{
-		$this->object->setMapID('map_canvas');
+		$this->object->setMapId('map_canvas');
 		$id = $this->object->getOption('mapid');
 		$this->assertEquals($id, 'map_canvas');
 	}
@@ -585,7 +585,7 @@ class JGoogleEmbedMapsTest extends PHPUnit_Framework_TestCase
 		$this->object->setZoom(8);
 		$this->object->setCenter('San Francisco', 'Home', array('centerkey' => 'value'));
 		$this->object->setMaptype('SATELLITE');
-		$this->object->setMapID('MAPID');
+		$this->object->setMapId('MAPID');
 		$this->object->setKey('123456');
 		$this->object->useSensor();
 		$this->object->setAdditionalMapOptions(array('mapkey1' => 5, 'mapkey2' => array ('subkey' => 'subvalue')));
@@ -648,7 +648,7 @@ class JGoogleEmbedMapsTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testGetBody()
 	{
-		$this->object->setMapID('MAPID');
+		$this->object->setMapId('MAPID');
 		$this->object->setMapClass('class1 class2');
 		$this->object->setMapStyle('width: 100%');
 

--- a/src/Data.php
+++ b/src/Data.php
@@ -79,7 +79,7 @@ abstract class Data
 	 * @since   1.0
 	 * @throws  UnexpectedValueException
 	 */
-	protected static function safeXML($data)
+	protected static function safeXml($data)
 	{
 		try
 		{

--- a/src/Data/Picasa.php
+++ b/src/Data/Picasa.php
@@ -53,7 +53,7 @@ class Picasa extends Data
 		{
 			$url = 'https://picasaweb.google.com/data/feed/api/user/' . urlencode($userID);
 			$jdata = $this->query($url, null, array('GData-Version' => 2));
-			$xml = $this->safeXML($jdata->body);
+			$xml = $this->safeXml($jdata->body);
 
 			if (isset($xml->children()->entry))
 			{
@@ -114,7 +114,7 @@ class Picasa extends Data
 			$url = 'https://picasaweb.google.com/data/feed/api/user/' . urlencode($userID);
 			$jdata = $this->query($url, $xml->asXML(), array('GData-Version' => 2, 'Content-type' => 'application/atom+xml'), 'post');
 
-			$xml = $this->safeXML($jdata->body);
+			$xml = $this->safeXml($jdata->body);
 
 			return new Picasa\Album($xml, $this->options, $this->auth);
 		}
@@ -139,7 +139,7 @@ class Picasa extends Data
 		if ($this->isAuthenticated())
 		{
 			$jdata = $this->query($url, null, array('GData-Version' => 2));
-			$xml = $this->safeXML($jdata->body);
+			$xml = $this->safeXml($jdata->body);
 
 			return new Picasa\Album($xml, $this->options, $this->auth);
 		}

--- a/src/Data/Picasa/Album.php
+++ b/src/Data/Picasa/Album.php
@@ -301,7 +301,7 @@ class Album extends Data
 				throw $e;
 			}
 
-			$this->xml = $this->safeXML($jdata->body);
+			$this->xml = $this->safeXml($jdata->body);
 
 			return $this;
 		}
@@ -324,7 +324,7 @@ class Album extends Data
 		{
 			$url = $this->getLink();
 			$jdata = $this->query($url, null, array('GData-Version' => 2));
-			$this->xml = $this->safeXML($jdata->body);
+			$this->xml = $this->safeXml($jdata->body);
 
 			return $this;
 		}
@@ -348,7 +348,7 @@ class Album extends Data
 		{
 			$url = $this->getLink('http://schemas.google.com/g/2005#feed');
 			$jdata = $this->query($url, null, array('GData-Version' => 2));
-			$xml = $this->safeXML($jdata->body);
+			$xml = $this->safeXml($jdata->body);
 
 			if (isset($xml->children()->entry))
 			{
@@ -391,7 +391,7 @@ class Album extends Data
 		{
 			$title = $title != '' ? $title : basename($file);
 
-			if (!($type = $this->getMIME($file)))
+			if (!($type = $this->getMime($file)))
 			{
 				throw new \RuntimeException("Inappropriate file type.");
 			}
@@ -419,7 +419,7 @@ class Album extends Data
 
 			$jdata = $this->query($this->getLink(), $post, array('GData-Version' => 2, 'Content-Type: multipart/related'), 'post');
 
-			return new Photo($this->safeXML($jdata->body), $this->options, $this->auth);
+			return new Photo($this->safeXml($jdata->body), $this->options, $this->auth);
 		}
 		else
 		{
@@ -437,7 +437,7 @@ class Album extends Data
 	 * @since   1.0
 	 * @throws  \UnexpectedValueException
 	 */
-	protected function getMIME($file)
+	protected function getMime($file)
 	{
 		switch (strtolower(pathinfo($file, PATHINFO_EXTENSION)))
 		{

--- a/src/Data/Picasa/Photo.php
+++ b/src/Data/Picasa/Photo.php
@@ -130,7 +130,7 @@ class Photo extends Data
 	 *
 	 * @since   1.0
 	 */
-	public function getURL()
+	public function getUrl()
 	{
 		return (string) $this->xml->children()->content->attributes()->src;
 	}
@@ -343,7 +343,7 @@ class Photo extends Data
 				throw $e;
 			}
 
-			$this->xml = $this->safeXML($jdata->body);
+			$this->xml = $this->safeXml($jdata->body);
 
 			return $this;
 		}
@@ -366,7 +366,7 @@ class Photo extends Data
 		{
 			$url = $this->getLink();
 			$jdata = $this->query($url, null, array('GData-Version' => 2));
-			$this->xml = $this->safeXML($jdata->body);
+			$this->xml = $this->safeXml($jdata->body);
 
 			return $this;
 		}

--- a/src/Embed/Maps.php
+++ b/src/Embed/Maps.php
@@ -79,7 +79,7 @@ class Maps extends Embed
 	 *
 	 * @since   1.0
 	 */
-	public function getMapID()
+	public function getMapId()
 	{
 		return $this->getOption('mapid') ? $this->getOption('mapid') : 'map_canvas';
 	}
@@ -93,7 +93,7 @@ class Maps extends Embed
 	 *
 	 * @since   1.0
 	 */
-	public function setMapID($id)
+	public function setMapId($id)
 	{
 		$this->setOption('mapid', $id);
 
@@ -564,7 +564,7 @@ class Maps extends Embed
 		$zoom = $this->getZoom();
 		$center = $this->getCenter();
 		$maptype = $this->getMapType();
-		$id = $this->getMapID();
+		$id = $this->getMapId();
 		$scheme = $this->isSecure() ? 'https' : 'http';
 		$key = $this->getKey();
 		$sensor = $this->hasSensor() ? 'true' : 'false';
@@ -649,7 +649,7 @@ class Maps extends Embed
 	 */
 	public function getBody()
 	{
-		$id = $this->getMapID();
+		$id = $this->getMapId();
 		$class = $this->getMapClass();
 		$style = $this->getMapStyle();
 


### PR DESCRIPTION
This PR fixes some more method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).

Not touching casing of class names as this requires changes in casing in file names and causes issues at this point.