### PR TITLE
Change scheme for the google maps api call to https and include an api key if one was set

### DIFF
--- a/Tests/JGoogleEmbedMapsTest.php
+++ b/Tests/JGoogleEmbedMapsTest.php
@@ -742,7 +742,10 @@ class JGoogleEmbedMapsTest extends PHPUnit_Framework_TestCase
  */
 function mapsGeocodeCallback($url, array $headers = null, $timeout = null)
 {
-	parse_str($url, $params);
+	$query = parse_url($url, PHP_URL_QUERY);
+	
+	parse_str($query, $params);
+	
 	$address = strtolower($params['address']);
 
 	switch ($address)

--- a/src/Embed/Maps.php
+++ b/src/Embed/Maps.php
@@ -682,8 +682,16 @@ class Maps extends Embed
 	 */
 	public function geocodeAddress($address)
 	{
-		$url = 'http://maps.googleapis.com/maps/api/geocode/json?sensor=false&address=' . urlencode($address);
-		$response = $this->http->get($url);
+		$uri = JUri::getInstance('https://maps.googleapis.com/maps/api/geocode/json');
+
+		$uri->setVar('address', urlencode($address));
+
+		if (($key = $this->getKey()))
+		{
+			$uri->setVar('key', $key);
+		}
+
+		$response = $this->http->get($uri->toString());
 
 		if ($response->code < 200 || $response->code >= 300)
 		{

--- a/src/Embed/Maps.php
+++ b/src/Embed/Maps.php
@@ -682,7 +682,7 @@ class Maps extends Embed
 	 */
 	public function geocodeAddress($address)
 	{
-		$uri = JUri::getInstance('https://maps.googleapis.com/maps/api/geocode/json');
+		$uri = new Uri('https://maps.googleapis.com/maps/api/geocode/json');
 
 		$uri->setVar('address', urlencode($address));
 


### PR DESCRIPTION
As requested in [#10439](https://github.com/joomla/joomla-cms/pull/10439) for the joomla-cms repo, this PR aims to add a google api key to the request if one was set and changes the schema / protocol to https instead of http.

